### PR TITLE
Add `-J-Xmx7g` buildArg to fix graalvm build in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test GraalVM CI
+
+on:
+  push:
+    branches: [ main, fix-graalvm ]
+    paths:
+      - '.github/workflows/test.yml'
+  pull_request:
+    branches: [ main, fix-graalvm ]
+    paths:
+      - '.github/workflows/test.yml'
+
+concurrency:
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MAVEN_OPTS: -Dhttps.protocols=TLSv1.2 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true
+
+jobs:
+  test-ci:
+    name: Test CI - JDK 17 on ubuntu-latest
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v3
+      - uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '17.0.8'
+          distribution: 'graalvm-community'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download Source and build Native Image
+        run: |
+          ./mvnw -PgenerateStandardMetadata -DskipNativeTests -B -T1C clean test
+          ./mvnw -am -pl distribution/proxy-native -B -T1C -Prelease.native -DskipTests clean package

--- a/distribution/proxy-native/pom.xml
+++ b/distribution/proxy-native/pom.xml
@@ -107,6 +107,7 @@
                             <verbose>true</verbose>
                             <buildArgs>
                                 <arg>--report-unsupported-elements-at-runtime</arg>
+                                <arg>-J-Xmx7g</arg>
                             </buildArgs>
                             <metadataRepository>
                                 <enabled>true</enabled>


### PR DESCRIPTION
Fixes https://github.com/oracle/graal/issues/7214.

Changes proposed in this pull request:
  - Add `-J-Xmx7g` buildArg to fix graalvm build in GitHub Actions.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
